### PR TITLE
use exec and absolute path for native bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-native-internal:
 	$(MVN_CMD) package
 	cp native/target/native-jar-with-dependencies.jar $(BUILD_PATH); \
 	echo "#!/bin/sh" > $(BUILD_PATH)/native; \
-	echo "java -jar native-jar-with-dependencies.jar" >> $(BUILD_PATH)/native; \
+	echo "exec java -jar $(BUILD_PATH)/native-jar-with-dependencies.jar" >> $(BUILD_PATH)/native; \
 	chmod +x $(BUILD_PATH)/native
 
 


### PR DESCRIPTION
* use exec to execute the JVM

* use absolute path to jar in native bin, so it does not depend on the
  working directory.