### PR TITLE
native: Use a intermediate bytestream to handle stream closing

### DIFF
--- a/native/src/main/java/bblfsh/ResponseWriter.java
+++ b/native/src/main/java/bblfsh/ResponseWriter.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -28,8 +29,12 @@ public class ResponseWriter {
     }
 
     public void write(final Response response) throws IOException {
-        mapper.writeValue(this.out, response);
-        this.out.write('\n');
+        // mapper closes the output stream after write, that's why we use an
+        // intermediate output stream
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, response);
+        out.write('\n');
+        this.out.write(out.toByteArray());
     }
 
 }


### PR DESCRIPTION
This should fix both #19 and #23. As can be seen at https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/ObjectMapper.java#L3898, the output stream is being closed by the object mapper after the value is written, causing the problem.

Surprisingly, trying to write on a closed stream doesn't generate any exception, which made the problem harder to solve.

Note that I don't know any Java, so there may be a better way to solve this, please let me know if that's the case (cc: @bzz)