### PR TITLE
Add support for all currently supported node types. 

### DIFF
--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -125,6 +125,7 @@
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ArrayCreation'\] | Expression, Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ThisExpression'\] | This, Expression |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Block'\] | BlockScope, Block, Statement |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='EmptyStatement'\] | Statement |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ExpressionStatement'\] | Statement |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ReturnStatement'\] | Return, Statement |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='BreakStatement'\] | Break, Statement |

--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -1,6 +1,5 @@
 | Path | Action |
 |------|--------|
-| /self::\*\[not\(@InternalType='CompilationUnit'\)\] | Error |
 | /self::\*\[@InternalType='CompilationUnit'\] | File |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='QualifiedName'\] | QualifiedIdentifier, Expression |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SimpleName'\] | SimpleIdentifier, Expression |

--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -23,9 +23,15 @@
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MethodDeclaration'\]/\*\[@internalRole\]\[@internalRole='parameters'\] | FunctionDeclarationArgument |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MethodDeclaration'\]/\*\[@internalRole\]\[@internalRole='parameters'\]/self::\*\[@varargs\]\[@varargs='true'\] | FunctionDeclarationVarArgsList |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MethodDeclaration'\]/\*\[@internalRole\]\[@internalRole='parameters'\]/\*\[@internalRole\]\[@internalRole='name'\] | FunctionDeclarationArgumentName |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='LambdaExpression'\] | FunctionDeclaration, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='LambdaExpression'\]/\*\[@internalRole\]\[@internalRole='body'\] | FunctionDeclarationBody |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='LambdaExpression'\]/\*\[@internalRole\]\[@internalRole='parameters'\] | FunctionDeclarationArgument |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='LambdaExpression'\]/\*\[@internalRole\]\[@internalRole='parameters'\]/self::\*\[@varargs\]\[@varargs='true'\] | FunctionDeclarationVarArgsList |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='LambdaExpression'\]/\*\[@internalRole\]\[@internalRole='parameters'\]/\*\[@internalRole\]\[@internalRole='name'\] | FunctionDeclarationArgumentName |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='AnnotationTypeMemberDeclaration'\] | Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='EnumConstantDeclaration'\] | Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='FieldDeclaration'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Initializer'\] | Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SingleVariableDeclaration'\] | Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='VariableDeclarationExpression'\] | Expression, Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='VariableDeclarationFragment'\] | Incomplete |
@@ -36,10 +42,23 @@
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='NumberLiteral'\] | NumberLiteral, Expression |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='StringLiteral'\] | StringLiteral, Expression |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TypeLiteral'\] | TypeLiteral, Expression |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ClassInstanceCreation'\] | Call, Expression, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ClassInstanceCreation'\]/\*\[@internalRole\]\[@internalRole='type'\] | CallCallee |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ClassInstanceCreation'\]/\*\[@internalRole\]\[@internalRole='arguments'\] | CallPositionalArgument |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ConstructorInvocation'\] | Call, Statement, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ConstructorInvocation'\]/\*\[@internalRole\]\[@internalRole='type'\] | CallCallee |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ConstructorInvocation'\]/\*\[@internalRole\]\[@internalRole='arguments'\] | CallPositionalArgument |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MethodInvocation'\] | Call, Expression |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MethodInvocation'\]/\*\[@internalRole\]\[@internalRole='expression'\] | CallReceiver |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MethodInvocation'\]/\*\[@internalRole\]\[@internalRole='name'\] | CallCallee |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MethodInvocation'\]/\*\[@internalRole\]\[@internalRole='arguments'\] | CallPositionalArgument |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SuperConstructorInvocation'\] | Call, Statement, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SuperConstructorInvocation'\]/\*\[@internalRole\]\[@internalRole='expression'\] | CallReceiver |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SuperConstructorInvocation'\]/\*\[@internalRole\]\[@internalRole='arguments'\] | CallPositionalArgument |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SuperMethodInvocation'\] | Call, Expression, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SuperMethodInvocation'\]/\*\[@internalRole\]\[@internalRole='qualifier'\] | CallCallee |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SuperMethodInvocation'\]/\*\[@internalRole\]\[@internalRole='name'\] | CallCallee |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SuperMethodInvocation'\]/\*\[@internalRole\]\[@internalRole='arguments'\] | CallPositionalArgument |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='IfStatement'\] | If, Statement |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='IfStatement'\]/\*\[@internalRole\]\[@internalRole='expression'\] | IfCondition |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='IfStatement'\]/\*\[@internalRole\]\[@internalRole='thenStatement'\] | IfBody |
@@ -134,10 +153,27 @@
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='AssertStatement'\] | Assert, Statement |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ArrayAccess'\] | Expression, Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ArrayCreation'\] | Expression, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='CastExpression'\] | Expression, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='CreationReference'\] | Expression, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ExpressionMethodReference'\] | Expression, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ParenthesizedExpression'\] | Expression, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SuperMethodReference'\] | Expression, Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ThisExpression'\] | This, Expression |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Block'\] | BlockScope, Block, Statement |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='BreakStatement'\] | Break, Statement |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='EmptyStatement'\] | Statement |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ExpressionStatement'\] | Statement |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='LabeledStatement'\] | Statement, Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ReturnStatement'\] | Return, Statement |
-| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='BreakStatement'\] | Break, Statement |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SynchronizedStatement'\] | Statement, Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ArrayInitializer'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Dimension'\] | Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Javadoc'\] | Documentation, Comment |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='NormalAnnotation'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MemberRef'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MemberValuePair'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MethodRef'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='MethodRefParameter'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TagElement'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TextElement'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TypeParameter'\] | Incomplete |

--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -106,6 +106,15 @@
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Assignment'\]/self::\*\[not\(@operator\]\[@operator='='\)\]/self::\*\[@operator\]\[@operator='<<='\] | OpBitwiseLeftShift |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Assignment'\]/self::\*\[not\(@operator\]\[@operator='='\)\]/self::\*\[@operator\]\[@operator='>>='\] | OpBitwiseRightShift |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Assignment'\]/self::\*\[not\(@operator\]\[@operator='='\)\]/self::\*\[@operator\]\[@operator='>>>='\] | OpBitwiseUnsignedRightShift |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ArrayType'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='IntersectionType'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='NameQualifiedType'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='ParameterizedType'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='PrimitiveType'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='QualifiedType'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SimpleType'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='UnionType'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='WildcardType'\] | Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TryStatement'\] | Try, Statement |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TryStatement'\]/\*\[@internalRole\]\[@internalRole='body'\] | TryBody |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TryStatement'\]/\*\[@internalRole\]\[@internalRole='catchClauses'\] | TryCatch |

--- a/ANNOTATION.md
+++ b/ANNOTATION.md
@@ -115,6 +115,17 @@
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='SimpleType'\] | Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='UnionType'\] | Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='WildcardType'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='public'\] | VisibleFromWorld |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='protected'\] | VisibleFromSubtype |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='private'\] | VisibleFromInstance |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='abstract'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='static'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='final'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='strictfp'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='transient'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='volatile'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='synchronized'\] | Incomplete |
+| /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='Modifier'\]/self::\*\[@Token='native'\] | Incomplete |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TryStatement'\] | Try, Statement |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TryStatement'\]/\*\[@internalRole\]\[@internalRole='body'\] | TryBody |
 | /self::\*\[@InternalType='CompilationUnit'\]//\*\[@InternalType='TryStatement'\]/\*\[@internalRole\]\[@internalRole='catchClauses'\] | TryCatch |

--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -208,6 +208,7 @@ var AnnotationRules = On(jdt.CompilationUnit).Roles(File).Descendants(
 
 	// Other statements
 	On(jdt.Block).Roles(BlockScope, Block, Statement),
+	On(jdt.EmptyStatement).Roles(Statement),
 	On(jdt.ExpressionStatement).Roles(Statement),
 	On(jdt.ReturnStatement).Roles(Return, Statement),
 	On(jdt.BreakStatement).Roles(Break, Statement),

--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -1,211 +1,206 @@
 package normalizer
 
 import (
-	"errors"
-
 	"github.com/bblfsh/java-driver/driver/normalizer/jdt"
 
 	. "github.com/bblfsh/sdk/uast"
 	. "github.com/bblfsh/sdk/uast/ann"
 )
 
-var AnnotationRules = On(Any).Self(
-	On(Not(jdt.CompilationUnit)).Error(errors.New("root must be CompilationUnit")),
-	On(jdt.CompilationUnit).Roles(File).Descendants(
-		// Names
-		On(jdt.QualifiedName).Roles(QualifiedIdentifier, Expression),
-		On(jdt.SimpleName).Roles(SimpleIdentifier, Expression),
+var AnnotationRules = On(jdt.CompilationUnit).Roles(File).Descendants(
+	// Names
+	On(jdt.QualifiedName).Roles(QualifiedIdentifier, Expression),
+	On(jdt.SimpleName).Roles(SimpleIdentifier, Expression),
 
-		// Visibility
-		On(Or(jdt.MethodDeclaration, jdt.TypeDeclaration)).Self(
-			On(HasChild(And(jdt.Modifier, jdt.KeywordPublic))).Roles(VisibleFromWorld),
-			On(HasChild(And(jdt.Modifier, jdt.KeywordPrivate))).Roles(VisibleFromType),
-			On(HasChild(And(jdt.Modifier, jdt.KeywordProtected))).Roles(VisibleFromSubtype),
-			On(Not(HasChild(And(jdt.Modifier,
-				Or(jdt.KeywordPublic, jdt.KeywordPrivate, jdt.KeywordProtected),
-			)))).Roles(VisibleFromPackage),
-		),
-
-		// Package and imports
-		On(jdt.PackageDeclaration).Roles(PackageDeclaration),
-		On(jdt.ImportDeclaration).Roles(ImportDeclaration).Children(
-			On(jdt.QualifiedName).Roles(ImportPath),
-		),
-
-		// Type declarations
-		On(jdt.AnonymousClassDeclaration).Roles(TypeDeclaration, Expression, Incomplete).Children(
-			On(jdt.PropertyBodyDeclarations).Roles(TypeDeclarationBody),
-		),
-		On(jdt.AnnotationTypeDeclaration).Roles(TypeDeclaration, Incomplete).Children(
-			On(jdt.PropertyBodyDeclarations).Roles(TypeDeclarationBody),
-		),
-		On(jdt.EnumDeclaration).Roles(TypeDeclaration, Incomplete),
-
-		// ClassDeclaration | InterfaceDeclaration
-		On(jdt.TypeDeclaration).Roles(TypeDeclaration),
-		// Local (TypeDeclaration | EnumDeclaration)
-		On(jdt.TypeDeclarationStatement).Roles(TypeDeclaration, Incomplete),
-
-		// Method declarations
-		On(jdt.MethodDeclaration).Roles(FunctionDeclaration).Children(
-			//TODO: On(jdt.PropertyTypeParameters).Roles(FunctionDeclarationTypeParameter),
-			//TODO: On(jdt.PropertyReturnType2).Roles(FunctionDeclarationReturnType)
-			On(jdt.PropertyName).Roles(FunctionDeclarationName),
-			On(jdt.PropertyBody).Roles(FunctionDeclarationBody),
-			On(jdt.PropertyParameters).Roles(FunctionDeclarationArgument).Self(
-				On(HasProperty("varargs", "true")).Roles(FunctionDeclarationVarArgsList),
-			).Children(
-				//TODO: On(jdt.PropertyType).Roles(FunctionDeclarationArgumentType),
-				On(jdt.PropertyName).Roles(FunctionDeclarationArgumentName),
-			),
-		),
-
-		// Other declarations
-		On(jdt.AnnotationTypeMemberDeclaration).Roles(Incomplete),
-		On(jdt.EnumConstantDeclaration).Roles(Incomplete),
-		On(jdt.FieldDeclaration).Roles(Incomplete),
-		On(jdt.SingleVariableDeclaration).Roles(Incomplete),
-		On(jdt.VariableDeclarationExpression).Roles(Expression, Incomplete),
-		On(jdt.VariableDeclarationFragment).Roles(Incomplete),
-		On(jdt.VariableDeclarationStatement).Roles(Statement, Incomplete),
-
-		// Literals
-		On(jdt.BooleanLiteral).Roles(BooleanLiteral, Expression),
-		On(jdt.CharacterLiteral).Roles(CharacterLiteral, Expression),
-		On(jdt.NullLiteral).Roles(NullLiteral, Expression),
-		On(jdt.NumberLiteral).Roles(NumberLiteral, Expression),
-		On(jdt.StringLiteral).Roles(StringLiteral, Expression),
-		On(jdt.TypeLiteral).Roles(TypeLiteral, Expression),
-
-		// Calls
-		On(jdt.MethodInvocation).Roles(Call, Expression).Children(
-			On(jdt.PropertyExpression).Roles(CallReceiver),
-			On(jdt.PropertyName).Roles(CallCallee),
-			On(jdt.PropertyArguments).Roles(CallPositionalArgument),
-		),
-
-		// Conditionals
-		On(jdt.IfStatement).Roles(If, Statement).Children(
-			On(jdt.PropertyExpression).Roles(IfCondition),
-			On(jdt.PropertyThenStatement).Roles(IfBody),
-			On(jdt.PropertyElseStatement).Roles(IfElse),
-		),
-
-		On(jdt.SwitchStatement).Roles(Switch, Statement).Children(
-			//TODO: On(jdt.PropertyExpression).Roles(SwitchExpression),
-			On(jdt.SwitchCase).Roles(Statement).Self(
-				On(HasChild(Any)).Roles(SwitchCase).Children(
-					On(jdt.PropertyExpression).Roles(SwitchCaseCondition),
-				),
-				On(Not(HasChild(Any))).Roles(SwitchDefault),
-			),
-			// FIXME: Switch case bodies are not enclosed in a block, thus it may
-			// contain an arbitrary number of statements (of any kind). So this
-			// is just an initial approach.
-			On(jdt.ExpressionStatement).Roles(SwitchCaseBody),
-		),
-
-		// Loops
-		On(jdt.EnhancedForStatement).Roles(ForEach, Statement).Children(
-			On(jdt.PropertyParameter).Roles(ForInit, ForUpdate),
-			On(jdt.PropertyExpression).Roles(ForExpression),
-			On(jdt.PropertyBody).Roles(ForBody),
-		),
-
-		On(jdt.ForStatement).Roles(For, Statement).Children(
-			On(jdt.PropertyInitializers).Roles(ForInit),
-			On(jdt.PropertyExpression).Roles(ForExpression),
-			On(jdt.PropertyUpdaters).Roles(ForUpdate),
-			On(jdt.PropertyBody).Roles(ForBody),
-		),
-
-		On(jdt.WhileStatement).Roles(While, Statement).Children(
-			On(jdt.PropertyExpression).Roles(WhileCondition),
-			On(jdt.PropertyBody).Roles(WhileBody),
-		),
-
-		On(jdt.DoStatement).Roles(DoWhile, Statement).Children(
-			On(jdt.PropertyExpression).Roles(DoWhileCondition),
-			On(jdt.PropertyBody).Roles(DoWhileBody),
-		),
-
-		// Operators
-		On(jdt.InfixExpression).Roles(BinaryExpression, BinaryExpressionOp, Expression).Self(
-			On(HasProperty("operator", "+")).Roles(OpAdd),
-			On(HasProperty("operator", "-")).Roles(OpSubstract),
-			On(HasProperty("operator", "*")).Roles(OpMultiply),
-			On(HasProperty("operator", "/")).Roles(OpDivide),
-			On(HasProperty("operator", "%")).Roles(OpMod),
-			On(HasProperty("operator", "<<")).Roles(OpBitwiseLeftShift),
-			On(HasProperty("operator", ">>")).Roles(OpBitwiseRightShift),
-			On(HasProperty("operator", ">>>")).Roles(OpBitwiseUnsignedRightShift),
-			On(HasProperty("operator", "&")).Roles(OpBitwiseAnd),
-			On(HasProperty("operator", "|")).Roles(OpBitwiseOr),
-			On(HasProperty("operator", "&&")).Roles(OpBooleanAnd),
-			On(HasProperty("operator", "||")).Roles(OpBooleanOr),
-			On(HasProperty("operator", "^")).Roles(OpBooleanXor),
-		).Children(
-			On(jdt.PropertyLeftOperand).Roles(BinaryExpressionLeft),
-			On(jdt.PropertyRightOperand).Roles(BinaryExpressionRight),
-		),
-
-		On(jdt.PostfixExpression).Roles(Expression).Self(
-			On(HasProperty("operator", "++")).Roles(OpPostIncrement),
-			On(HasProperty("operator", "--")).Roles(OpPostDecrement),
-		),
-
-		On(jdt.PrefixExpression).Roles(Expression).Self(
-			On(HasProperty("operator", "++")).Roles(OpPreIncrement),
-			On(HasProperty("operator", "--")).Roles(OpPreDecrement),
-			On(HasProperty("operator", "+")).Roles(OpPositive),
-			On(HasProperty("operator", "-")).Roles(OpNegative),
-			On(HasProperty("operator", "~")).Roles(OpBitwiseComplement),
-			On(HasProperty("operator", "!")).Roles(OpBooleanNot),
-		),
-
-		On(jdt.Assignment).Roles(Assignment, Expression).Children(
-			On(jdt.PropertyLeftHandSide).Roles(AssignmentVariable),
-			On(jdt.PropertyRightHandSide).Roles(AssignmentValue),
-		).Self(
-			On(Not(HasProperty("operator", "="))).Roles(AugmentedAssignmentOperator, AugmentedAssignment).Self(
-				On(HasProperty("operator", "+=")).Roles(OpAdd),
-				On(HasProperty("operator", "-=")).Roles(OpSubstract),
-				On(HasProperty("operator", "*=")).Roles(OpMultiply),
-				On(HasProperty("operator", "/=")).Roles(OpDivide),
-				On(HasProperty("operator", "%=")).Roles(OpMod),
-				On(HasProperty("operator", "&=")).Roles(OpBitwiseAnd),
-				On(HasProperty("operator", "|=")).Roles(OpBitwiseOr),
-				On(HasProperty("operator", "^=")).Roles(OpBooleanXor),
-				On(HasProperty("operator", "<<=")).Roles(OpBitwiseLeftShift),
-				On(HasProperty("operator", ">>=")).Roles(OpBitwiseRightShift),
-				On(HasProperty("operator", ">>>=")).Roles(OpBitwiseUnsignedRightShift),
-			),
-		),
-
-		// Exceptions
-		On(jdt.TryStatement).Roles(Try, Statement).Children(
-			// TODO: TryWithResourcesStatement
-			On(jdt.PropertyBody).Roles(TryBody),
-			On(jdt.PropertyCatchClauses).Roles(TryCatch),
-			On(jdt.PropertyFinally).Roles(TryFinally),
-		),
-
-		On(jdt.ThrowStatement).Roles(Throw, Statement),
-
-		On(jdt.AssertStatement).Roles(Assert, Statement),
-
-		// Other expressions
-		On(jdt.ArrayAccess).Roles(Expression, Incomplete),
-		On(jdt.ArrayCreation).Roles(Expression, Incomplete),
-		On(jdt.ThisExpression).Roles(This, Expression),
-
-		// Other statements
-		On(jdt.Block).Roles(BlockScope, Block, Statement),
-		On(jdt.ExpressionStatement).Roles(Statement),
-		On(jdt.ReturnStatement).Roles(Return, Statement),
-		On(jdt.BreakStatement).Roles(Break, Statement),
-
-		//TODO: synchronized
-		On(jdt.Javadoc).Roles(Documentation, Comment),
+	// Visibility
+	On(Or(jdt.MethodDeclaration, jdt.TypeDeclaration)).Self(
+		On(HasChild(And(jdt.Modifier, jdt.KeywordPublic))).Roles(VisibleFromWorld),
+		On(HasChild(And(jdt.Modifier, jdt.KeywordPrivate))).Roles(VisibleFromType),
+		On(HasChild(And(jdt.Modifier, jdt.KeywordProtected))).Roles(VisibleFromSubtype),
+		On(Not(HasChild(And(jdt.Modifier,
+			Or(jdt.KeywordPublic, jdt.KeywordPrivate, jdt.KeywordProtected),
+		)))).Roles(VisibleFromPackage),
 	),
+
+	// Package and imports
+	On(jdt.PackageDeclaration).Roles(PackageDeclaration),
+	On(jdt.ImportDeclaration).Roles(ImportDeclaration).Children(
+		On(jdt.QualifiedName).Roles(ImportPath),
+	),
+
+	// Type declarations
+	On(jdt.AnonymousClassDeclaration).Roles(TypeDeclaration, Expression, Incomplete).Children(
+		On(jdt.PropertyBodyDeclarations).Roles(TypeDeclarationBody),
+	),
+	On(jdt.AnnotationTypeDeclaration).Roles(TypeDeclaration, Incomplete).Children(
+		On(jdt.PropertyBodyDeclarations).Roles(TypeDeclarationBody),
+	),
+	On(jdt.EnumDeclaration).Roles(TypeDeclaration, Incomplete),
+
+	// ClassDeclaration | InterfaceDeclaration
+	On(jdt.TypeDeclaration).Roles(TypeDeclaration),
+	// Local (TypeDeclaration | EnumDeclaration)
+	On(jdt.TypeDeclarationStatement).Roles(TypeDeclaration, Incomplete),
+
+	// Method declarations
+	On(jdt.MethodDeclaration).Roles(FunctionDeclaration).Children(
+		//TODO: On(jdt.PropertyTypeParameters).Roles(FunctionDeclarationTypeParameter),
+		//TODO: On(jdt.PropertyReturnType2).Roles(FunctionDeclarationReturnType)
+		On(jdt.PropertyName).Roles(FunctionDeclarationName),
+		On(jdt.PropertyBody).Roles(FunctionDeclarationBody),
+		On(jdt.PropertyParameters).Roles(FunctionDeclarationArgument).Self(
+			On(HasProperty("varargs", "true")).Roles(FunctionDeclarationVarArgsList),
+		).Children(
+			//TODO: On(jdt.PropertyType).Roles(FunctionDeclarationArgumentType),
+			On(jdt.PropertyName).Roles(FunctionDeclarationArgumentName),
+		),
+	),
+
+	// Other declarations
+	On(jdt.AnnotationTypeMemberDeclaration).Roles(Incomplete),
+	On(jdt.EnumConstantDeclaration).Roles(Incomplete),
+	On(jdt.FieldDeclaration).Roles(Incomplete),
+	On(jdt.SingleVariableDeclaration).Roles(Incomplete),
+	On(jdt.VariableDeclarationExpression).Roles(Expression, Incomplete),
+	On(jdt.VariableDeclarationFragment).Roles(Incomplete),
+	On(jdt.VariableDeclarationStatement).Roles(Statement, Incomplete),
+
+	// Literals
+	On(jdt.BooleanLiteral).Roles(BooleanLiteral, Expression),
+	On(jdt.CharacterLiteral).Roles(CharacterLiteral, Expression),
+	On(jdt.NullLiteral).Roles(NullLiteral, Expression),
+	On(jdt.NumberLiteral).Roles(NumberLiteral, Expression),
+	On(jdt.StringLiteral).Roles(StringLiteral, Expression),
+	On(jdt.TypeLiteral).Roles(TypeLiteral, Expression),
+
+	// Calls
+	On(jdt.MethodInvocation).Roles(Call, Expression).Children(
+		On(jdt.PropertyExpression).Roles(CallReceiver),
+		On(jdt.PropertyName).Roles(CallCallee),
+		On(jdt.PropertyArguments).Roles(CallPositionalArgument),
+	),
+
+	// Conditionals
+	On(jdt.IfStatement).Roles(If, Statement).Children(
+		On(jdt.PropertyExpression).Roles(IfCondition),
+		On(jdt.PropertyThenStatement).Roles(IfBody),
+		On(jdt.PropertyElseStatement).Roles(IfElse),
+	),
+
+	On(jdt.SwitchStatement).Roles(Switch, Statement).Children(
+		//TODO: On(jdt.PropertyExpression).Roles(SwitchExpression),
+		On(jdt.SwitchCase).Roles(Statement).Self(
+			On(HasChild(Any)).Roles(SwitchCase).Children(
+				On(jdt.PropertyExpression).Roles(SwitchCaseCondition),
+			),
+			On(Not(HasChild(Any))).Roles(SwitchDefault),
+		),
+		// FIXME: Switch case bodies are not enclosed in a block, thus it may
+		// contain an arbitrary number of statements (of any kind). So this
+		// is just an initial approach.
+		On(jdt.ExpressionStatement).Roles(SwitchCaseBody),
+	),
+
+	// Loops
+	On(jdt.EnhancedForStatement).Roles(ForEach, Statement).Children(
+		On(jdt.PropertyParameter).Roles(ForInit, ForUpdate),
+		On(jdt.PropertyExpression).Roles(ForExpression),
+		On(jdt.PropertyBody).Roles(ForBody),
+	),
+
+	On(jdt.ForStatement).Roles(For, Statement).Children(
+		On(jdt.PropertyInitializers).Roles(ForInit),
+		On(jdt.PropertyExpression).Roles(ForExpression),
+		On(jdt.PropertyUpdaters).Roles(ForUpdate),
+		On(jdt.PropertyBody).Roles(ForBody),
+	),
+
+	On(jdt.WhileStatement).Roles(While, Statement).Children(
+		On(jdt.PropertyExpression).Roles(WhileCondition),
+		On(jdt.PropertyBody).Roles(WhileBody),
+	),
+
+	On(jdt.DoStatement).Roles(DoWhile, Statement).Children(
+		On(jdt.PropertyExpression).Roles(DoWhileCondition),
+		On(jdt.PropertyBody).Roles(DoWhileBody),
+	),
+
+	// Operators
+	On(jdt.InfixExpression).Roles(BinaryExpression, BinaryExpressionOp, Expression).Self(
+		On(HasProperty("operator", "+")).Roles(OpAdd),
+		On(HasProperty("operator", "-")).Roles(OpSubstract),
+		On(HasProperty("operator", "*")).Roles(OpMultiply),
+		On(HasProperty("operator", "/")).Roles(OpDivide),
+		On(HasProperty("operator", "%")).Roles(OpMod),
+		On(HasProperty("operator", "<<")).Roles(OpBitwiseLeftShift),
+		On(HasProperty("operator", ">>")).Roles(OpBitwiseRightShift),
+		On(HasProperty("operator", ">>>")).Roles(OpBitwiseUnsignedRightShift),
+		On(HasProperty("operator", "&")).Roles(OpBitwiseAnd),
+		On(HasProperty("operator", "|")).Roles(OpBitwiseOr),
+		On(HasProperty("operator", "&&")).Roles(OpBooleanAnd),
+		On(HasProperty("operator", "||")).Roles(OpBooleanOr),
+		On(HasProperty("operator", "^")).Roles(OpBooleanXor),
+	).Children(
+		On(jdt.PropertyLeftOperand).Roles(BinaryExpressionLeft),
+		On(jdt.PropertyRightOperand).Roles(BinaryExpressionRight),
+	),
+
+	On(jdt.PostfixExpression).Roles(Expression).Self(
+		On(HasProperty("operator", "++")).Roles(OpPostIncrement),
+		On(HasProperty("operator", "--")).Roles(OpPostDecrement),
+	),
+
+	On(jdt.PrefixExpression).Roles(Expression).Self(
+		On(HasProperty("operator", "++")).Roles(OpPreIncrement),
+		On(HasProperty("operator", "--")).Roles(OpPreDecrement),
+		On(HasProperty("operator", "+")).Roles(OpPositive),
+		On(HasProperty("operator", "-")).Roles(OpNegative),
+		On(HasProperty("operator", "~")).Roles(OpBitwiseComplement),
+		On(HasProperty("operator", "!")).Roles(OpBooleanNot),
+	),
+
+	On(jdt.Assignment).Roles(Assignment, Expression).Children(
+		On(jdt.PropertyLeftHandSide).Roles(AssignmentVariable),
+		On(jdt.PropertyRightHandSide).Roles(AssignmentValue),
+	).Self(
+		On(Not(HasProperty("operator", "="))).Roles(AugmentedAssignmentOperator, AugmentedAssignment).Self(
+			On(HasProperty("operator", "+=")).Roles(OpAdd),
+			On(HasProperty("operator", "-=")).Roles(OpSubstract),
+			On(HasProperty("operator", "*=")).Roles(OpMultiply),
+			On(HasProperty("operator", "/=")).Roles(OpDivide),
+			On(HasProperty("operator", "%=")).Roles(OpMod),
+			On(HasProperty("operator", "&=")).Roles(OpBitwiseAnd),
+			On(HasProperty("operator", "|=")).Roles(OpBitwiseOr),
+			On(HasProperty("operator", "^=")).Roles(OpBooleanXor),
+			On(HasProperty("operator", "<<=")).Roles(OpBitwiseLeftShift),
+			On(HasProperty("operator", ">>=")).Roles(OpBitwiseRightShift),
+			On(HasProperty("operator", ">>>=")).Roles(OpBitwiseUnsignedRightShift),
+		),
+	),
+
+	// Exceptions
+	On(jdt.TryStatement).Roles(Try, Statement).Children(
+		// TODO: TryWithResourcesStatement
+		On(jdt.PropertyBody).Roles(TryBody),
+		On(jdt.PropertyCatchClauses).Roles(TryCatch),
+		On(jdt.PropertyFinally).Roles(TryFinally),
+	),
+
+	On(jdt.ThrowStatement).Roles(Throw, Statement),
+
+	On(jdt.AssertStatement).Roles(Assert, Statement),
+
+	// Other expressions
+	On(jdt.ArrayAccess).Roles(Expression, Incomplete),
+	On(jdt.ArrayCreation).Roles(Expression, Incomplete),
+	On(jdt.ThisExpression).Roles(This, Expression),
+
+	// Other statements
+	On(jdt.Block).Roles(BlockScope, Block, Statement),
+	On(jdt.ExpressionStatement).Roles(Statement),
+	On(jdt.ReturnStatement).Roles(Return, Statement),
+	On(jdt.BreakStatement).Roles(Break, Statement),
+
+	//TODO: synchronized
+	On(jdt.Javadoc).Roles(Documentation, Comment),
 )

--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -178,6 +178,17 @@ var AnnotationRules = On(jdt.CompilationUnit).Roles(File).Descendants(
 		),
 	),
 
+	// Types
+	On(jdt.ArrayType).Roles(Incomplete),
+	On(jdt.IntersectionType).Roles(Incomplete),
+	On(jdt.NameQualifiedType).Roles(Incomplete),
+	On(jdt.ParameterizedType).Roles(Incomplete),
+	On(jdt.PrimitiveType).Roles(Incomplete),
+	On(jdt.QualifiedType).Roles(Incomplete),
+	On(jdt.SimpleType).Roles(Incomplete),
+	On(jdt.UnionType).Roles(Incomplete),
+	On(jdt.WildcardType).Roles(Incomplete),
+
 	// Exceptions
 	On(jdt.TryStatement).Roles(Try, Statement).Children(
 		// TODO: TryWithResourcesStatement

--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -189,6 +189,28 @@ var AnnotationRules = On(jdt.CompilationUnit).Roles(File).Descendants(
 	On(jdt.UnionType).Roles(Incomplete),
 	On(jdt.WildcardType).Roles(Incomplete),
 
+	// Modifiers
+	On(jdt.Modifier).Self(
+		On(jdt.KeywordPublic).Roles(VisibleFromWorld),
+		On(jdt.KeywordProtected).Roles(VisibleFromSubtype),
+		On(jdt.KeywordPrivate).Roles(VisibleFromInstance),
+
+		// class | method | interface
+		On(jdt.KeywordAbstract).Roles(Incomplete),
+		// class | field | method | interface
+		On(jdt.KeywordStatic).Roles(Incomplete),
+		// class | field | method
+		On(jdt.KeywordFinal).Roles(Incomplete),
+		// class | method | interface
+		On(jdt.KeywordStrictfp).Roles(Incomplete),
+		// field
+		On(jdt.KeywordTransient).Roles(Incomplete),
+		On(jdt.KeywordVolatile).Roles(Incomplete),
+		// method
+		On(jdt.KeywordSynchronized).Roles(Incomplete),
+		On(jdt.KeywordNative).Roles(Incomplete),
+	),
+
 	// Exceptions
 	On(jdt.TryStatement).Roles(Try, Statement).Children(
 		// TODO: TryWithResourcesStatement

--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -44,14 +44,22 @@ var AnnotationRules = On(jdt.CompilationUnit).Roles(File).Descendants(
 
 	// Method declarations
 	On(jdt.MethodDeclaration).Roles(FunctionDeclaration).Children(
-		//TODO: On(jdt.PropertyTypeParameters).Roles(FunctionDeclarationTypeParameter),
-		//TODO: On(jdt.PropertyReturnType2).Roles(FunctionDeclarationReturnType)
 		On(jdt.PropertyName).Roles(FunctionDeclarationName),
 		On(jdt.PropertyBody).Roles(FunctionDeclarationBody),
 		On(jdt.PropertyParameters).Roles(FunctionDeclarationArgument).Self(
 			On(HasProperty("varargs", "true")).Roles(FunctionDeclarationVarArgsList),
 		).Children(
-			//TODO: On(jdt.PropertyType).Roles(FunctionDeclarationArgumentType),
+			On(jdt.PropertyName).Roles(FunctionDeclarationArgumentName),
+		),
+	),
+	// FIXME: A lambda expression is not really a function declaration
+	// but current UAST doesn't provide anything else for function definitions
+	// so I'm considering a lambda expression a function declaration for now
+	On(jdt.LambdaExpression).Roles(FunctionDeclaration, Incomplete).Children(
+		On(jdt.PropertyBody).Roles(FunctionDeclarationBody),
+		On(jdt.PropertyParameters).Roles(FunctionDeclarationArgument).Self(
+			On(HasProperty("varargs", "true")).Roles(FunctionDeclarationVarArgsList),
+		).Children(
 			On(jdt.PropertyName).Roles(FunctionDeclarationArgumentName),
 		),
 	),
@@ -60,6 +68,7 @@ var AnnotationRules = On(jdt.CompilationUnit).Roles(File).Descendants(
 	On(jdt.AnnotationTypeMemberDeclaration).Roles(Incomplete),
 	On(jdt.EnumConstantDeclaration).Roles(Incomplete),
 	On(jdt.FieldDeclaration).Roles(Incomplete),
+	On(jdt.Initializer).Roles(Incomplete),
 	On(jdt.SingleVariableDeclaration).Roles(Incomplete),
 	On(jdt.VariableDeclarationExpression).Roles(Expression, Incomplete),
 	On(jdt.VariableDeclarationFragment).Roles(Incomplete),
@@ -74,8 +83,25 @@ var AnnotationRules = On(jdt.CompilationUnit).Roles(File).Descendants(
 	On(jdt.TypeLiteral).Roles(TypeLiteral, Expression),
 
 	// Calls
+	On(jdt.ClassInstanceCreation).Roles(Call, Expression, Incomplete).Children(
+		On(jdt.PropertyType).Roles(CallCallee),
+		On(jdt.PropertyArguments).Roles(CallPositionalArgument),
+	),
+	On(jdt.ConstructorInvocation).Roles(Call, Statement, Incomplete).Children(
+		On(jdt.PropertyType).Roles(CallCallee),
+		On(jdt.PropertyArguments).Roles(CallPositionalArgument),
+	),
 	On(jdt.MethodInvocation).Roles(Call, Expression).Children(
 		On(jdt.PropertyExpression).Roles(CallReceiver),
+		On(jdt.PropertyName).Roles(CallCallee),
+		On(jdt.PropertyArguments).Roles(CallPositionalArgument),
+	),
+	On(jdt.SuperConstructorInvocation).Roles(Call, Statement, Incomplete).Children(
+		On(jdt.PropertyExpression).Roles(CallReceiver),
+		On(jdt.PropertyArguments).Roles(CallPositionalArgument),
+	),
+	On(jdt.SuperMethodInvocation).Roles(Call, Expression, Incomplete).Children(
+		On(jdt.PropertyQualifier).Roles(CallCallee),
 		On(jdt.PropertyName).Roles(CallCallee),
 		On(jdt.PropertyArguments).Roles(CallPositionalArgument),
 	),
@@ -226,15 +252,32 @@ var AnnotationRules = On(jdt.CompilationUnit).Roles(File).Descendants(
 	// Other expressions
 	On(jdt.ArrayAccess).Roles(Expression, Incomplete),
 	On(jdt.ArrayCreation).Roles(Expression, Incomplete),
+	On(jdt.CastExpression).Roles(Expression, Incomplete),
+	On(jdt.CreationReference).Roles(Expression, Incomplete),
+	On(jdt.ExpressionMethodReference).Roles(Expression, Incomplete),
+	On(jdt.ParenthesizedExpression).Roles(Expression, Incomplete),
+	On(jdt.SuperMethodReference).Roles(Expression, Incomplete),
 	On(jdt.ThisExpression).Roles(This, Expression),
 
 	// Other statements
 	On(jdt.Block).Roles(BlockScope, Block, Statement),
+	On(jdt.BreakStatement).Roles(Break, Statement),
 	On(jdt.EmptyStatement).Roles(Statement),
 	On(jdt.ExpressionStatement).Roles(Statement),
+	On(jdt.LabeledStatement).Roles(Statement, Incomplete),
 	On(jdt.ReturnStatement).Roles(Return, Statement),
-	On(jdt.BreakStatement).Roles(Break, Statement),
+	On(jdt.SynchronizedStatement).Roles(Statement, Incomplete),
 
-	//TODO: synchronized
+	// Others
+	On(jdt.ArrayInitializer).Roles(Incomplete),
+	On(jdt.Dimension).Roles(Incomplete),
 	On(jdt.Javadoc).Roles(Documentation, Comment),
+	On(jdt.NormalAnnotation).Roles(Incomplete),
+	On(jdt.MemberRef).Roles(Incomplete),
+	On(jdt.MemberValuePair).Roles(Incomplete),
+	On(jdt.MethodRef).Roles(Incomplete),
+	On(jdt.MethodRefParameter).Roles(Incomplete),
+	On(jdt.TagElement).Roles(Incomplete),
+	On(jdt.TextElement).Roles(Incomplete),
+	On(jdt.TypeParameter).Roles(Incomplete),
 )

--- a/tests/annotation_type_member_declaration.uast
+++ b/tests/annotation_type_member_declaration.uast
@@ -29,7 +29,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 17

--- a/tests/anonymous_class_declaration.uast
+++ b/tests/anonymous_class_declaration.uast
@@ -67,7 +67,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 29
@@ -109,7 +109,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -159,7 +159,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 64

--- a/tests/anonymous_class_declaration.uast
+++ b/tests/anonymous_class_declaration.uast
@@ -103,13 +103,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: ClassInstanceCreation {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Call,Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: expression
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: CallCallee,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/anonymous_class_declaration.uast
+++ b/tests/anonymous_class_declaration.uast
@@ -147,7 +147,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: VisibleFromWorld
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "public"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 57

--- a/tests/array.uast
+++ b/tests/array.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 14
@@ -77,13 +77,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: ArrayType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32
@@ -127,13 +127,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: ArrayType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 46
@@ -177,7 +177,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 58

--- a/tests/array.uast
+++ b/tests/array.uast
@@ -95,7 +95,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: Dimension {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: dimensions
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -145,7 +145,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: Dimension {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: dimensions
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/array_initializer.uast
+++ b/tests/array_initializer.uast
@@ -95,7 +95,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: Dimension {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: dimensions
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -121,7 +121,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ArrayInitializer {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: initializer
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/array_initializer.uast
+++ b/tests/array_initializer.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 14
@@ -77,13 +77,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: ArrayType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32

--- a/tests/assert.uast
+++ b/tests/assert.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15

--- a/tests/binary_expression.uast
+++ b/tests/binary_expression.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33

--- a/tests/boolean_operators.uast
+++ b/tests/boolean_operators.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "boolean"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33

--- a/tests/break.uast
+++ b/tests/break.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15

--- a/tests/cast_expression.uast
+++ b/tests/cast_expression.uast
@@ -107,7 +107,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: CastExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: initializer
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/cast_expression.uast
+++ b/tests/cast_expression.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33
@@ -113,7 +113,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 42

--- a/tests/character_literal.uast
+++ b/tests/character_literal.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "char"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33

--- a/tests/constructor_invocation.uast
+++ b/tests/constructor_invocation.uast
@@ -59,13 +59,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: ConstructorInvocation {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Call,Statement,Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: statements
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: NumberLiteral {
-.  .  .  .  .  .  .  .  .  .  .  Roles: NumberLiteral,Expression
+.  .  .  .  .  .  .  .  .  .  .  Roles: NumberLiteral,Expression,CallPositionalArgument
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 3

--- a/tests/constructor_invocation.uast
+++ b/tests/constructor_invocation.uast
@@ -119,7 +119,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 48

--- a/tests/creation_reference.uast
+++ b/tests/creation_reference.uast
@@ -238,7 +238,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: CreationReference {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: initializer
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/creation_reference.uast
+++ b/tests/creation_reference.uast
@@ -152,13 +152,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: ParameterizedType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -178,7 +178,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: typeArguments
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -198,7 +198,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: typeArguments
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -244,7 +244,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/do_while.uast
+++ b/tests/do_while.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 14
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33

--- a/tests/empty.native
+++ b/tests/empty.native
@@ -1,0 +1,9 @@
+{
+    "status": "ok",
+    "errors": [],
+    "ast": {
+        "CompilationUnit": {
+            "internalClass": "CompilationUnit"
+        }
+    }
+}

--- a/tests/empty.uast
+++ b/tests/empty.uast
@@ -1,0 +1,7 @@
+Status:  ok
+Errors: 
+UAST: 
+CompilationUnit {
+.  Roles: File
+}
+

--- a/tests/empty_statement.uast
+++ b/tests/empty_statement.uast
@@ -146,7 +146,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: EmptyStatement {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Statement
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: statements
 .  .  .  .  .  .  .  .  .  }

--- a/tests/expression_method_reference.uast
+++ b/tests/expression_method_reference.uast
@@ -152,13 +152,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: ParameterizedType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -178,7 +178,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: typeArguments
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -198,7 +198,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: typeArguments
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/expression_method_reference.uast
+++ b/tests/expression_method_reference.uast
@@ -238,7 +238,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ExpressionMethodReference {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: initializer
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/field_access.uast
+++ b/tests/field_access.uast
@@ -35,7 +35,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: VisibleFromInstance
 .  .  .  .  .  .  .  TOKEN "private"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -47,7 +47,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "final"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 23

--- a/tests/field_access.uast
+++ b/tests/field_access.uast
@@ -59,7 +59,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 29

--- a/tests/for.uast
+++ b/tests/for.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 14
@@ -83,7 +83,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 38

--- a/tests/foreach.uast
+++ b/tests/foreach.uast
@@ -139,7 +139,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: Dimension {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: dimensions
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -147,7 +147,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: ArrayInitializer {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: initializer
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/foreach.uast
+++ b/tests/foreach.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 14
@@ -89,7 +89,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 38
@@ -121,13 +121,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: ArrayType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 50

--- a/tests/hello_world.uast
+++ b/tests/hello_world.uast
@@ -65,7 +65,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 29
@@ -101,13 +101,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: ArrayType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: elementType
 .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/hello_world.uast
+++ b/tests/hello_world.uast
@@ -127,7 +127,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  1: Dimension {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: dimensions
 .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/hello_world.uast
+++ b/tests/hello_world.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: VisibleFromWorld
 .  .  .  .  .  .  .  TOKEN "public"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -53,7 +53,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "static"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 22

--- a/tests/if.uast
+++ b/tests/if.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15

--- a/tests/ifelse.uast
+++ b/tests/ifelse.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15

--- a/tests/initializer.uast
+++ b/tests/initializer.uast
@@ -105,7 +105,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  2: Initializer {
-.  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: bodyDeclarations
 .  .  .  .  .  }

--- a/tests/initializer.uast
+++ b/tests/initializer.uast
@@ -35,7 +35,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: VisibleFromInstance
 .  .  .  .  .  .  .  TOKEN "private"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -47,7 +47,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "final"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 23
@@ -59,7 +59,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "static"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 29
@@ -111,7 +111,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "static"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 45

--- a/tests/initializer.uast
+++ b/tests/initializer.uast
@@ -71,7 +71,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  3: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 36

--- a/tests/intersection_type.uast
+++ b/tests/intersection_type.uast
@@ -59,7 +59,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: SimpleType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: typeBounds
 .  .  .  .  .  .  .  .  .  }
@@ -79,7 +79,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  2: SimpleType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: typeBounds
 .  .  .  .  .  .  .  .  .  }
@@ -125,7 +125,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  }
@@ -227,13 +227,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: IntersectionType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: types
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -253,7 +253,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: types
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/intersection_type.uast
+++ b/tests/intersection_type.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: TypeParameter {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: typeParameters
 .  .  .  .  .  .  .  }
@@ -221,7 +221,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: CastExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: CallPositionalArgument
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: CallPositionalArgument,Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: arguments
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/labeled_statement.uast
+++ b/tests/labeled_statement.uast
@@ -59,7 +59,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: LabeledStatement {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Statement,Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: statements
 .  .  .  .  .  .  .  .  .  }

--- a/tests/labeled_statement.uast
+++ b/tests/labeled_statement.uast
@@ -89,7 +89,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36

--- a/tests/lambda_expession.uast
+++ b/tests/lambda_expession.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 21
@@ -167,7 +167,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/lambda_expession.uast
+++ b/tests/lambda_expession.uast
@@ -205,7 +205,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: LambdaExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: FunctionDeclaration,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 65
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 6
@@ -217,13 +217,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: VariableDeclarationFragment {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: FunctionDeclarationArgument,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: parameters
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleName {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: SimpleIdentifier,Expression
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: SimpleIdentifier,Expression,FunctionDeclarationArgumentName
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "i"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 66
@@ -237,7 +237,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: BinaryExpression,BinaryExpressionOp,Expression,OpAdd
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: FunctionDeclarationBody,BinaryExpression,BinaryExpressionOp,Expression,OpAdd
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 72
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 6

--- a/tests/member_ref.uast
+++ b/tests/member_ref.uast
@@ -47,13 +47,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: TagElement {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: tags
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: TagElement {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 2
@@ -65,7 +65,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: MemberRef {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: fragments
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -87,7 +87,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  1: TextElement {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 29
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 2

--- a/tests/member_value_pair.uast
+++ b/tests/member_value_pair.uast
@@ -29,7 +29,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  }

--- a/tests/member_value_pair.uast
+++ b/tests/member_value_pair.uast
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  }
 .  .  .  Children: {
 .  .  .  .  0: NormalAnnotation {
-.  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: modifiers
 .  .  .  .  .  }
@@ -95,7 +95,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: MemberValuePair {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: values
 .  .  .  .  .  .  .  }

--- a/tests/method_declarations.uast
+++ b/tests/method_declarations.uast
@@ -481,7 +481,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: TypeParameter {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: typeParameters
 .  .  .  .  .  .  .  }
@@ -608,7 +608,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: TypeParameter {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: typeParameters
 .  .  .  .  .  .  .  }
@@ -628,7 +628,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: TypeParameter {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: typeParameters
 .  .  .  .  .  .  .  }

--- a/tests/method_declarations.uast
+++ b/tests/method_declarations.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 17
@@ -109,7 +109,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 57
@@ -153,7 +153,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 95
@@ -189,7 +189,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 108
@@ -257,7 +257,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 133
@@ -293,7 +293,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 149
@@ -331,7 +331,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 156
@@ -399,7 +399,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 181
@@ -435,7 +435,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 199
@@ -501,7 +501,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: SimpleType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: returnType2
 .  .  .  .  .  .  .  }
@@ -545,7 +545,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 237
@@ -648,7 +648,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  2: SimpleType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: returnType2
 .  .  .  .  .  .  .  }
@@ -692,7 +692,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  }

--- a/tests/method_declarations.uast
+++ b/tests/method_declarations.uast
@@ -85,7 +85,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: VisibleFromWorld
 .  .  .  .  .  .  .  TOKEN "public"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 43
@@ -97,7 +97,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "static"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 50

--- a/tests/method_ref.uast
+++ b/tests/method_ref.uast
@@ -95,7 +95,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32

--- a/tests/method_ref.uast
+++ b/tests/method_ref.uast
@@ -47,13 +47,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: TagElement {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: tags
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: TagElement {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 19
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 2
@@ -65,7 +65,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: MethodRef {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: fragments
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -83,7 +83,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: MethodRefParameter {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 32
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 2
@@ -125,7 +125,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  1: TextElement {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 39
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 2

--- a/tests/operators.uast
+++ b/tests/operators.uast
@@ -1255,7 +1255,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: ParenthesizedExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: expression
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -2307,13 +2307,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: ClassInstanceCreation {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Call,Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: leftOperand
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: CallCallee,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -2333,7 +2333,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: BooleanLiteral {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: BooleanLiteral,Expression
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: BooleanLiteral,Expression,CallPositionalArgument
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 494
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 52

--- a/tests/operators.uast
+++ b/tests/operators.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 14
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 30
@@ -1817,7 +1817,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "boolean"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 381
@@ -2313,7 +2313,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -2347,7 +2347,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: rightOperand
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/qualified_identifier.uast
+++ b/tests/qualified_identifier.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/return.uast
+++ b/tests/return.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15

--- a/tests/single_variable_declaration.uast
+++ b/tests/single_variable_declaration.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "boolean"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 25

--- a/tests/super_constructor_invocation.uast
+++ b/tests/super_constructor_invocation.uast
@@ -59,7 +59,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: SuperConstructorInvocation {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Call,Statement,Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: statements
 .  .  .  .  .  .  .  .  .  }

--- a/tests/super_field_access.uast
+++ b/tests/super_field_access.uast
@@ -47,7 +47,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 19
@@ -107,7 +107,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: SimpleType {
-.  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: superclassType
 .  .  .  .  .  }
@@ -145,7 +145,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 58

--- a/tests/super_field_access.uast
+++ b/tests/super_field_access.uast
@@ -35,7 +35,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: VisibleFromWorld
 .  .  .  .  .  .  .  TOKEN "public"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 12
@@ -133,7 +133,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: VisibleFromWorld
 .  .  .  .  .  .  .  TOKEN "public"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 51

--- a/tests/super_method_invocation.uast
+++ b/tests/super_method_invocation.uast
@@ -167,13 +167,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: SuperMethodInvocation {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Call,Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: expression
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleName {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: SimpleIdentifier,Expression
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: SimpleIdentifier,Expression,CallCallee
 .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "a"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 69

--- a/tests/super_method_invocation.uast
+++ b/tests/super_method_invocation.uast
@@ -53,7 +53,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 19
@@ -111,7 +111,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: SimpleType {
-.  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: superclassType
 .  .  .  .  .  }

--- a/tests/super_method_invocation.uast
+++ b/tests/super_method_invocation.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: VisibleFromWorld
 .  .  .  .  .  .  .  TOKEN "public"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 12

--- a/tests/super_method_reference.uast
+++ b/tests/super_method_reference.uast
@@ -140,7 +140,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 56
@@ -176,7 +176,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 62
@@ -284,7 +284,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  }
 .  .  .  .  1: SimpleType {
-.  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  Properties: {
 .  .  .  .  .  .  internalRole: superclassType
 .  .  .  .  .  }
@@ -340,13 +340,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: ParameterizedType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -366,7 +366,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: typeArguments
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -386,7 +386,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  2: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: typeArguments
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/super_method_reference.uast
+++ b/tests/super_method_reference.uast
@@ -426,7 +426,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: SuperMethodReference {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: initializer
 .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/super_method_reference.uast
+++ b/tests/super_method_reference.uast
@@ -128,7 +128,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: VisibleFromWorld
 .  .  .  .  .  .  .  TOKEN "public"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 49

--- a/tests/switch.uast
+++ b/tests/switch.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 17

--- a/tests/synchronized_statement.uast
+++ b/tests/synchronized_statement.uast
@@ -161,7 +161,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: SynchronizedStatement {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Statement,Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: statements
 .  .  .  .  .  .  .  .  .  }

--- a/tests/synchronized_statement.uast
+++ b/tests/synchronized_statement.uast
@@ -47,7 +47,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  }
 .  .  .  .  .  .  1: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 23
@@ -93,7 +93,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 32
@@ -129,7 +129,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  Offset: 42

--- a/tests/synchronized_statement.uast
+++ b/tests/synchronized_statement.uast
@@ -35,7 +35,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: Modifier {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: VisibleFromInstance
 .  .  .  .  .  .  .  TOKEN "private"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15

--- a/tests/throw.uast
+++ b/tests/throw.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15

--- a/tests/try_catch.uast
+++ b/tests/try_catch.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15
@@ -95,7 +95,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }

--- a/tests/try_finally.uast
+++ b/tests/try_finally.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 15

--- a/tests/type_declaration_statement.uast
+++ b/tests/type_declaration_statement.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 11

--- a/tests/type_declaration_statement.uast
+++ b/tests/type_declaration_statement.uast
@@ -105,7 +105,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: EmptyStatement {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Statement
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: statements
 .  .  .  .  .  .  .  .  .  }

--- a/tests/type_literal.uast
+++ b/tests/type_literal.uast
@@ -41,13 +41,13 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: ParameterizedType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  internalRole: returnType2
 .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  0: SimpleType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  }
@@ -67,7 +67,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  1: SimpleType {
-.  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  internalRole: typeArguments
 .  .  .  .  .  .  .  .  .  }
@@ -119,7 +119,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 36

--- a/tests/variable_declarations.uast
+++ b/tests/variable_declarations.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 14
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33
@@ -117,7 +117,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 45
@@ -169,7 +169,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 61
@@ -229,7 +229,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 76
@@ -301,7 +301,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 95
@@ -373,7 +373,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 114
@@ -457,7 +457,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 137

--- a/tests/while.uast
+++ b/tests/while.uast
@@ -41,7 +41,7 @@ CompilationUnit {
 .  .  .  .  .  }
 .  .  .  .  .  Children: {
 .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  TOKEN "void"
 .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  Offset: 14
@@ -77,7 +77,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrimitiveType {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  Roles: Incomplete
 .  .  .  .  .  .  .  .  .  .  .  TOKEN "int"
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 33


### PR DESCRIPTION
Every node that appears in tests/ samples has now a role,
so there are no Unannotated roles at the moment