### PR TITLE
annotations: Annotate TypeMethodReference and its children.

### DIFF
--- a/driver/normalizer/annotation.go
+++ b/driver/normalizer/annotation.go
@@ -75,6 +75,11 @@ var AnnotationRules = On(jdt.CompilationUnit).Roles(uast.File).Descendants(
 			On(jdt.PropertyName).Roles(uast.Function, uast.Name),
 		),
 	),
+	On(jdt.TypeMethodReference).Roles(uast.Declaration, uast.Function).Children(
+		On(jdt.PropertyName).Roles(uast.Function, uast.Name),
+		On(jdt.PropertyTypeArguments).Roles(uast.Function, uast.Argument),
+		On(jdt.PropertyType).Roles(uast.Function, uast.Return),
+	),
 
 	// Other declarations
 	On(jdt.AnnotationTypeMemberDeclaration).Roles(uast.Declaration, uast.Type, uast.Incomplete),

--- a/fixtures/type_method_reference.uast
+++ b/fixtures/type_method_reference.uast
@@ -493,13 +493,13 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: TypeMethodReference {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Unannotated
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Declaration,Function
 .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: initializer
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  0: ArrayType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Type,Primitive,List
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Function,Return,Type,Primitive,List
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: type
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -557,7 +557,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: SimpleType {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Type
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Function,Argument,Type
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Properties: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  internalRole: typeArguments
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
@@ -582,7 +582,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  2: SimpleName {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Identifier
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Identifier,Function,Name
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  TOKEN "clone"
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 173


### PR DESCRIPTION
Signed-off-by: Alfredo Beaumont <alfredo.beaumont@gmail.com>