### PR TITLE
Extract the comment texts + remove comment marks (//, /* */, /**)

### DIFF
--- a/fixtures/binary_expression.java.uast
+++ b/fixtures/binary_expression.java.uast
@@ -143,7 +143,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Add,Arithmetic
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Arithmetic,Add
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 41
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 3

--- a/fixtures/block_comment.java
+++ b/fixtures/block_comment.java
@@ -1,3 +1,9 @@
 /* block comment before */
 class A { /* block comment inline */ }
 /* block comment after */
+
+/*
+ * This is a multiline
+ * block comment
+ * end
+ */

--- a/fixtures/block_comment.java
+++ b/fixtures/block_comment.java
@@ -1,2 +1,3 @@
-/* a */
-class A { /* b */ }
+/* block comment before */
+class A { /* block comment inline */ }
+/* block comment after */

--- a/fixtures/block_comment.java.native
+++ b/fixtures/block_comment.java.native
@@ -6,45 +6,54 @@
         "CompilationUnit": {
             "comments": [
                 {
-                    "endColumn": 8,
+                    "endColumn": 27,
                     "endLine": 1,
-                    "endPosition": 7,
+                    "endPosition": 26,
                     "internalClass": "BlockComment",
                     "startColumn": 1,
                     "startLine": 1,
                     "startPosition": 0
                 },
                 {
-                    "endColumn": 18,
+                    "endColumn": 37,
                     "endLine": 2,
-                    "endPosition": 25,
+                    "endPosition": 63,
                     "internalClass": "BlockComment",
                     "startColumn": 11,
                     "startLine": 2,
-                    "startPosition": 18
+                    "startPosition": 37
+                },
+                {
+                    "endColumn": 26,
+                    "endLine": 3,
+                    "endPosition": 91,
+                    "internalClass": "BlockComment",
+                    "startColumn": 1,
+                    "startLine": 3,
+                    "startPosition": 66
                 }
             ],
             "internalClass": "CompilationUnit",
             "types": [
                 {
-                    "endColumn": 0,
-                    "endLine": -1,
-                    "endPosition": 27,
+                    "endColumn": 39,
+                    "endLine": 2,
+                    "endPosition": 65,
                     "interface": "false",
                     "internalClass": "TypeDeclaration",
                     "name": {
                         "endColumn": 8,
                         "endLine": 2,
-                        "endPosition": 15,
+                        "endPosition": 34,
                         "identifier": "A",
                         "internalClass": "SimpleName",
                         "startColumn": 7,
                         "startLine": 2,
-                        "startPosition": 14
+                        "startPosition": 33
                     },
                     "startColumn": 1,
                     "startLine": 2,
-                    "startPosition": 8
+                    "startPosition": 27
                 }
             ]
         }

--- a/fixtures/block_comment.java.native
+++ b/fixtures/block_comment.java.native
@@ -12,7 +12,8 @@
                     "internalClass": "BlockComment",
                     "startColumn": 1,
                     "startLine": 1,
-                    "startPosition": 0
+                    "startPosition": 0,
+                    "text": "/* block comment before */"
                 },
                 {
                     "endColumn": 37,
@@ -21,7 +22,8 @@
                     "internalClass": "BlockComment",
                     "startColumn": 11,
                     "startLine": 2,
-                    "startPosition": 37
+                    "startPosition": 37,
+                    "text": "/* block comment inline */"
                 },
                 {
                     "endColumn": 26,
@@ -30,7 +32,18 @@
                     "internalClass": "BlockComment",
                     "startColumn": 1,
                     "startLine": 3,
-                    "startPosition": 66
+                    "startPosition": 66,
+                    "text": "/* block comment after */"
+                },
+                {
+                    "endColumn": 4,
+                    "endLine": 9,
+                    "endPosition": 146,
+                    "internalClass": "BlockComment",
+                    "startColumn": 1,
+                    "startLine": 5,
+                    "startPosition": 93,
+                    "text": "/*\n* This is a multiline\n* block comment\n* end\n*/"
                 }
             ],
             "internalClass": "CompilationUnit",

--- a/fixtures/block_comment.java.uast
+++ b/fixtures/block_comment.java.uast
@@ -13,9 +13,9 @@ CompilationUnit {
 .  .  .  .  Col: 1
 .  .  .  }
 .  .  .  EndPosition: {
-.  .  .  .  Offset: 7
+.  .  .  .  Offset: 26
 .  .  .  .  Line: 1
-.  .  .  .  Col: 8
+.  .  .  .  Col: 27
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments
@@ -24,14 +24,14 @@ CompilationUnit {
 .  .  1: TypeDeclaration {
 .  .  .  Roles: Visibility,Package,Declaration,Type
 .  .  .  StartPosition: {
-.  .  .  .  Offset: 8
+.  .  .  .  Offset: 27
 .  .  .  .  Line: 2
 .  .  .  .  Col: 1
 .  .  .  }
 .  .  .  EndPosition: {
-.  .  .  .  Offset: 27
-.  .  .  .  Line: 4294967295
-.  .  .  .  Col: 0
+.  .  .  .  Offset: 65
+.  .  .  .  Line: 2
+.  .  .  .  Col: 39
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  interface: false
@@ -42,12 +42,12 @@ CompilationUnit {
 .  .  .  .  .  Roles: Expression,Identifier
 .  .  .  .  .  TOKEN "A"
 .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  Offset: 14
+.  .  .  .  .  .  Offset: 33
 .  .  .  .  .  .  Line: 2
 .  .  .  .  .  .  Col: 7
 .  .  .  .  .  }
 .  .  .  .  .  EndPosition: {
-.  .  .  .  .  .  Offset: 15
+.  .  .  .  .  .  Offset: 34
 .  .  .  .  .  .  Line: 2
 .  .  .  .  .  .  Col: 8
 .  .  .  .  .  }
@@ -60,14 +60,30 @@ CompilationUnit {
 .  .  2: BlockComment {
 .  .  .  Roles: Comment
 .  .  .  StartPosition: {
-.  .  .  .  Offset: 18
+.  .  .  .  Offset: 37
 .  .  .  .  Line: 2
 .  .  .  .  Col: 11
 .  .  .  }
 .  .  .  EndPosition: {
-.  .  .  .  Offset: 25
+.  .  .  .  Offset: 63
 .  .  .  .  Line: 2
-.  .  .  .  Col: 18
+.  .  .  .  Col: 37
+.  .  .  }
+.  .  .  Properties: {
+.  .  .  .  internalRole: comments
+.  .  .  }
+.  .  }
+.  .  3: BlockComment {
+.  .  .  Roles: Comment
+.  .  .  StartPosition: {
+.  .  .  .  Offset: 66
+.  .  .  .  Line: 3
+.  .  .  .  Col: 1
+.  .  .  }
+.  .  .  EndPosition: {
+.  .  .  .  Offset: 91
+.  .  .  .  Line: 3
+.  .  .  .  Col: 26
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments

--- a/fixtures/block_comment.java.uast
+++ b/fixtures/block_comment.java.uast
@@ -19,6 +19,7 @@ CompilationUnit {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments
+.  .  .  .  text:  block comment before 
 .  .  .  }
 .  .  }
 .  .  1: TypeDeclaration {
@@ -71,6 +72,7 @@ CompilationUnit {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments
+.  .  .  .  text:  block comment inline 
 .  .  .  }
 .  .  }
 .  .  3: BlockComment {
@@ -87,6 +89,28 @@ CompilationUnit {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments
+.  .  .  .  text:  block comment after 
+.  .  .  }
+.  .  }
+.  .  4: BlockComment {
+.  .  .  Roles: Comment
+.  .  .  StartPosition: {
+.  .  .  .  Offset: 93
+.  .  .  .  Line: 5
+.  .  .  .  Col: 1
+.  .  .  }
+.  .  .  EndPosition: {
+.  .  .  .  Offset: 146
+.  .  .  .  Line: 9
+.  .  .  .  Col: 4
+.  .  .  }
+.  .  .  Properties: {
+.  .  .  .  internalRole: comments
+.  .  .  .  text: 
+* This is a multiline
+* block comment
+* end
+
 .  .  .  }
 .  .  }
 .  }

--- a/fixtures/empty.java.native
+++ b/fixtures/empty.java.native
@@ -1,10 +1,6 @@
 {
     "status": "ok",
-    "language": "java",
+    "language": "",
     "errors": [],
-    "ast": {
-        "CompilationUnit": {
-            "internalClass": "CompilationUnit"
-        }
-    }
+    "ast": null
 }

--- a/fixtures/empty.java.uast
+++ b/fixtures/empty.java.uast
@@ -1,8 +1,5 @@
 Status:  ok
-Language:  java
+Language:  
 Errors: 
 UAST: 
-CompilationUnit {
-.  Roles: File
-}
 

--- a/fixtures/javadoc.java
+++ b/fixtures/javadoc.java
@@ -1,0 +1,8 @@
+/** This is a javadoc comment */
+
+class A { /** javadoc comment inline */ }
+
+/**
+ * This is a multiline JavaDoc
+ * comment
+ * */

--- a/fixtures/javadoc.java.native
+++ b/fixtures/javadoc.java.native
@@ -1,0 +1,74 @@
+{
+    "status": "ok",
+    "language": "java",
+    "errors": [],
+    "ast": {
+        "CompilationUnit": {
+            "comments": [
+                {
+                    "endColumn": 40,
+                    "endLine": 3,
+                    "endPosition": 73,
+                    "internalClass": "Javadoc",
+                    "startColumn": 11,
+                    "startLine": 3,
+                    "startPosition": 44,
+                    "text": "/** javadoc comment inline */"
+                },
+                {
+                    "endColumn": 6,
+                    "endLine": 8,
+                    "endPosition": 128,
+                    "internalClass": "Javadoc",
+                    "startColumn": 1,
+                    "startLine": 5,
+                    "startPosition": 77,
+                    "text": "/**\n* This is a multiline JavaDoc\n* comment\n* */"
+                }
+            ],
+            "internalClass": "CompilationUnit",
+            "types": [
+                {
+                    "endColumn": 42,
+                    "endLine": 3,
+                    "endPosition": 75,
+                    "interface": "false",
+                    "internalClass": "TypeDeclaration",
+                    "javadoc": {
+                        "internalClass": "Javadoc",
+                        "tags": [
+                            {
+                                "fragments": [
+                                    {
+                                        "endColumn": 31,
+                                        "endLine": 1,
+                                        "endPosition": 30,
+                                        "internalClass": "TextElement",
+                                        "startColumn": 5,
+                                        "startLine": 1,
+                                        "startPosition": 4,
+                                        "text": "This is a javadoc comment "
+                                    }
+                                ],
+                                "internalClass": "TagElement"
+                            }
+                        ]
+                    },
+                    "name": {
+                        "endColumn": 8,
+                        "endLine": 3,
+                        "endPosition": 41,
+                        "identifier": "A",
+                        "internalClass": "SimpleName",
+                        "startColumn": 7,
+                        "startLine": 3,
+                        "startPosition": 40
+                    },
+                    "startColumn": 1,
+                    "startLine": 1,
+                    "startPosition": 0
+                }
+            ]
+        }
+    }
+}

--- a/fixtures/javadoc.java.uast
+++ b/fixtures/javadoc.java.uast
@@ -1,0 +1,116 @@
+Status:  ok
+Language:  java
+Errors: 
+UAST: 
+CompilationUnit {
+.  Roles: File
+.  Children: {
+.  .  0: TypeDeclaration {
+.  .  .  Roles: Visibility,Package,Declaration,Type
+.  .  .  StartPosition: {
+.  .  .  .  Offset: 0
+.  .  .  .  Line: 1
+.  .  .  .  Col: 1
+.  .  .  }
+.  .  .  EndPosition: {
+.  .  .  .  Offset: 75
+.  .  .  .  Line: 3
+.  .  .  .  Col: 42
+.  .  .  }
+.  .  .  Properties: {
+.  .  .  .  interface: false
+.  .  .  .  internalRole: types
+.  .  .  }
+.  .  .  Children: {
+.  .  .  .  0: Javadoc {
+.  .  .  .  .  Roles: Documentation,Comment
+.  .  .  .  .  Properties: {
+.  .  .  .  .  .  internalRole: javadoc
+.  .  .  .  .  }
+.  .  .  .  .  Children: {
+.  .  .  .  .  .  0: TagElement {
+.  .  .  .  .  .  .  Roles: Documentation,Incomplete
+.  .  .  .  .  .  .  Properties: {
+.  .  .  .  .  .  .  .  internalRole: tags
+.  .  .  .  .  .  .  }
+.  .  .  .  .  .  .  Children: {
+.  .  .  .  .  .  .  .  0: TextElement {
+.  .  .  .  .  .  .  .  .  Roles: Documentation,Incomplete
+.  .  .  .  .  .  .  .  .  StartPosition: {
+.  .  .  .  .  .  .  .  .  .  Offset: 4
+.  .  .  .  .  .  .  .  .  .  Line: 1
+.  .  .  .  .  .  .  .  .  .  Col: 5
+.  .  .  .  .  .  .  .  .  }
+.  .  .  .  .  .  .  .  .  EndPosition: {
+.  .  .  .  .  .  .  .  .  .  Offset: 30
+.  .  .  .  .  .  .  .  .  .  Line: 1
+.  .  .  .  .  .  .  .  .  .  Col: 31
+.  .  .  .  .  .  .  .  .  }
+.  .  .  .  .  .  .  .  .  Properties: {
+.  .  .  .  .  .  .  .  .  .  internalRole: fragments
+.  .  .  .  .  .  .  .  .  .  text: This is a javadoc comment 
+.  .  .  .  .  .  .  .  .  }
+.  .  .  .  .  .  .  .  }
+.  .  .  .  .  .  .  }
+.  .  .  .  .  .  }
+.  .  .  .  .  }
+.  .  .  .  }
+.  .  .  .  1: SimpleName {
+.  .  .  .  .  Roles: Expression,Identifier
+.  .  .  .  .  TOKEN "A"
+.  .  .  .  .  StartPosition: {
+.  .  .  .  .  .  Offset: 40
+.  .  .  .  .  .  Line: 3
+.  .  .  .  .  .  Col: 7
+.  .  .  .  .  }
+.  .  .  .  .  EndPosition: {
+.  .  .  .  .  .  Offset: 41
+.  .  .  .  .  .  Line: 3
+.  .  .  .  .  .  Col: 8
+.  .  .  .  .  }
+.  .  .  .  .  Properties: {
+.  .  .  .  .  .  internalRole: name
+.  .  .  .  .  }
+.  .  .  .  }
+.  .  .  }
+.  .  }
+.  .  1: Javadoc {
+.  .  .  Roles: Documentation,Comment
+.  .  .  StartPosition: {
+.  .  .  .  Offset: 44
+.  .  .  .  Line: 3
+.  .  .  .  Col: 11
+.  .  .  }
+.  .  .  EndPosition: {
+.  .  .  .  Offset: 73
+.  .  .  .  Line: 3
+.  .  .  .  Col: 40
+.  .  .  }
+.  .  .  Properties: {
+.  .  .  .  internalRole: comments
+.  .  .  .  text:  javadoc comment inline 
+.  .  .  }
+.  .  }
+.  .  2: Javadoc {
+.  .  .  Roles: Documentation,Comment
+.  .  .  StartPosition: {
+.  .  .  .  Offset: 77
+.  .  .  .  Line: 5
+.  .  .  .  Col: 1
+.  .  .  }
+.  .  .  EndPosition: {
+.  .  .  .  Offset: 128
+.  .  .  .  Line: 8
+.  .  .  .  Col: 6
+.  .  .  }
+.  .  .  Properties: {
+.  .  .  .  internalRole: comments
+.  .  .  .  text: 
+* This is a multiline JavaDoc
+* comment
+* 
+.  .  .  }
+.  .  }
+.  }
+}
+

--- a/fixtures/lambda_expession.java.uast
+++ b/fixtures/lambda_expession.java.uast
@@ -318,7 +318,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  1: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Function,Body,Expression,Binary,Operator,Add,Arithmetic
+.  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Function,Body,Expression,Binary,Operator,Arithmetic,Add
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 72
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 6

--- a/fixtures/line_comment.java
+++ b/fixtures/line_comment.java
@@ -1,3 +1,4 @@
-// a
-class A { // b
+// first comment before
+class A { // comment inline
 }
+// comment after

--- a/fixtures/line_comment.java.native
+++ b/fixtures/line_comment.java.native
@@ -6,45 +6,54 @@
         "CompilationUnit": {
             "comments": [
                 {
-                    "endColumn": 5,
+                    "endColumn": 24,
                     "endLine": 1,
-                    "endPosition": 4,
+                    "endPosition": 23,
                     "internalClass": "LineComment",
                     "startColumn": 1,
                     "startLine": 1,
                     "startPosition": 0
                 },
                 {
-                    "endColumn": 15,
+                    "endColumn": 28,
                     "endLine": 2,
-                    "endPosition": 19,
+                    "endPosition": 51,
                     "internalClass": "LineComment",
                     "startColumn": 11,
                     "startLine": 2,
-                    "startPosition": 15
+                    "startPosition": 34
+                },
+                {
+                    "endColumn": 17,
+                    "endLine": 4,
+                    "endPosition": 70,
+                    "internalClass": "LineComment",
+                    "startColumn": 1,
+                    "startLine": 4,
+                    "startPosition": 54
                 }
             ],
             "internalClass": "CompilationUnit",
             "types": [
                 {
-                    "endColumn": 0,
-                    "endLine": -1,
-                    "endPosition": 21,
+                    "endColumn": 2,
+                    "endLine": 3,
+                    "endPosition": 53,
                     "interface": "false",
                     "internalClass": "TypeDeclaration",
                     "name": {
                         "endColumn": 8,
                         "endLine": 2,
-                        "endPosition": 12,
+                        "endPosition": 31,
                         "identifier": "A",
                         "internalClass": "SimpleName",
                         "startColumn": 7,
                         "startLine": 2,
-                        "startPosition": 11
+                        "startPosition": 30
                     },
                     "startColumn": 1,
                     "startLine": 2,
-                    "startPosition": 5
+                    "startPosition": 24
                 }
             ]
         }

--- a/fixtures/line_comment.java.native
+++ b/fixtures/line_comment.java.native
@@ -12,7 +12,8 @@
                     "internalClass": "LineComment",
                     "startColumn": 1,
                     "startLine": 1,
-                    "startPosition": 0
+                    "startPosition": 0,
+                    "text": "// first comment before"
                 },
                 {
                     "endColumn": 28,
@@ -21,7 +22,8 @@
                     "internalClass": "LineComment",
                     "startColumn": 11,
                     "startLine": 2,
-                    "startPosition": 34
+                    "startPosition": 34,
+                    "text": "// comment inline"
                 },
                 {
                     "endColumn": 17,
@@ -30,7 +32,8 @@
                     "internalClass": "LineComment",
                     "startColumn": 1,
                     "startLine": 4,
-                    "startPosition": 54
+                    "startPosition": 54,
+                    "text": "// comment after"
                 }
             ],
             "internalClass": "CompilationUnit",

--- a/fixtures/line_comment.java.uast
+++ b/fixtures/line_comment.java.uast
@@ -19,6 +19,7 @@ CompilationUnit {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments
+.  .  .  .  text:  first comment before
 .  .  .  }
 .  .  }
 .  .  1: TypeDeclaration {
@@ -71,6 +72,7 @@ CompilationUnit {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments
+.  .  .  .  text:  comment inline
 .  .  .  }
 .  .  }
 .  .  3: LineComment {
@@ -87,6 +89,7 @@ CompilationUnit {
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments
+.  .  .  .  text:  comment after
 .  .  .  }
 .  .  }
 .  }

--- a/fixtures/line_comment.java.uast
+++ b/fixtures/line_comment.java.uast
@@ -13,9 +13,9 @@ CompilationUnit {
 .  .  .  .  Col: 1
 .  .  .  }
 .  .  .  EndPosition: {
-.  .  .  .  Offset: 4
+.  .  .  .  Offset: 23
 .  .  .  .  Line: 1
-.  .  .  .  Col: 5
+.  .  .  .  Col: 24
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments
@@ -24,14 +24,14 @@ CompilationUnit {
 .  .  1: TypeDeclaration {
 .  .  .  Roles: Visibility,Package,Declaration,Type
 .  .  .  StartPosition: {
-.  .  .  .  Offset: 5
+.  .  .  .  Offset: 24
 .  .  .  .  Line: 2
 .  .  .  .  Col: 1
 .  .  .  }
 .  .  .  EndPosition: {
-.  .  .  .  Offset: 21
-.  .  .  .  Line: 4294967295
-.  .  .  .  Col: 0
+.  .  .  .  Offset: 53
+.  .  .  .  Line: 3
+.  .  .  .  Col: 2
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  interface: false
@@ -42,12 +42,12 @@ CompilationUnit {
 .  .  .  .  .  Roles: Expression,Identifier
 .  .  .  .  .  TOKEN "A"
 .  .  .  .  .  StartPosition: {
-.  .  .  .  .  .  Offset: 11
+.  .  .  .  .  .  Offset: 30
 .  .  .  .  .  .  Line: 2
 .  .  .  .  .  .  Col: 7
 .  .  .  .  .  }
 .  .  .  .  .  EndPosition: {
-.  .  .  .  .  .  Offset: 12
+.  .  .  .  .  .  Offset: 31
 .  .  .  .  .  .  Line: 2
 .  .  .  .  .  .  Col: 8
 .  .  .  .  .  }
@@ -60,14 +60,30 @@ CompilationUnit {
 .  .  2: LineComment {
 .  .  .  Roles: Comment
 .  .  .  StartPosition: {
-.  .  .  .  Offset: 15
+.  .  .  .  Offset: 34
 .  .  .  .  Line: 2
 .  .  .  .  Col: 11
 .  .  .  }
 .  .  .  EndPosition: {
-.  .  .  .  Offset: 19
+.  .  .  .  Offset: 51
 .  .  .  .  Line: 2
-.  .  .  .  Col: 15
+.  .  .  .  Col: 28
+.  .  .  }
+.  .  .  Properties: {
+.  .  .  .  internalRole: comments
+.  .  .  }
+.  .  }
+.  .  3: LineComment {
+.  .  .  Roles: Comment
+.  .  .  StartPosition: {
+.  .  .  .  Offset: 54
+.  .  .  .  Line: 4
+.  .  .  .  Col: 1
+.  .  .  }
+.  .  .  EndPosition: {
+.  .  .  .  Offset: 70
+.  .  .  .  Line: 4
+.  .  .  .  Col: 17
 .  .  .  }
 .  .  .  Properties: {
 .  .  .  .  internalRole: comments

--- a/fixtures/operators.java.uast
+++ b/fixtures/operators.java.uast
@@ -187,7 +187,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Add,Arithmetic,Assignment,Right
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Arithmetic,Add,Assignment,Right
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 43
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 4
@@ -284,7 +284,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Substract,Arithmetic,Assignment,Right
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Arithmetic,Substract,Assignment,Right
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 56
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 5
@@ -381,7 +381,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Multiply,Arithmetic,Assignment,Right
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Arithmetic,Multiply,Assignment,Right
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 69
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 6
@@ -478,7 +478,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Divide,Arithmetic,Assignment,Right
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Arithmetic,Divide,Assignment,Right
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 82
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 7
@@ -575,7 +575,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Modulo,Arithmetic,Assignment,Right
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Arithmetic,Modulo,Assignment,Right
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 95
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 8
@@ -726,7 +726,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrefixExpression {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Operator,Unary,Increment
+.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Operator,Unary,Arithmetic,Increment
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 120
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 13
@@ -770,7 +770,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: PrefixExpression {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Operator,Unary,Decrement
+.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Operator,Unary,Arithmetic,Decrement
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 127
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 14
@@ -848,7 +848,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: PrefixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Operator,Unary,Positive,Assignment,Binary,Right
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Operator,Unary,Arithmetic,Positive,Assignment,Binary,Right
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 139
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 16
@@ -928,7 +928,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: PrefixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Operator,Unary,Negative,Assignment,Binary,Right
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Operator,Unary,Arithmetic,Negative,Assignment,Binary,Right
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 149
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 17
@@ -1747,7 +1747,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Assignment {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Add
+.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Arithmetic,Add
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 266
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 30
@@ -1808,7 +1808,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Assignment {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Substract
+.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Arithmetic,Substract
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 276
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 31
@@ -1869,7 +1869,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Assignment {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Multiply
+.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Arithmetic,Multiply
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 286
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 32
@@ -1930,7 +1930,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Assignment {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Divide
+.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Arithmetic,Divide
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 296
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 33
@@ -1991,7 +1991,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: Assignment {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Modulo
+.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Assignment,Operator,Binary,Arithmetic,Modulo
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 306
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 34
@@ -2582,7 +2582,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  .  .  .  1: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Equal,Relational,Not,Assignment,Right
+.  .  .  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Equal,Relational,Assignment,Right
 .  .  .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Offset: 413
 .  .  .  .  .  .  .  .  .  .  .  .  .  .  Line: 46

--- a/fixtures/super_method_reference.java.uast
+++ b/fixtures/super_method_reference.java.uast
@@ -285,7 +285,7 @@ CompilationUnit {
 .  .  .  .  .  .  .  .  .  }
 .  .  .  .  .  .  .  .  .  Children: {
 .  .  .  .  .  .  .  .  .  .  0: InfixExpression {
-.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Add,Arithmetic
+.  .  .  .  .  .  .  .  .  .  .  Roles: Expression,Binary,Operator,Arithmetic,Add
 .  .  .  .  .  .  .  .  .  .  .  StartPosition: {
 .  .  .  .  .  .  .  .  .  .  .  .  Offset: 78
 .  .  .  .  .  .  .  .  .  .  .  .  Line: 4

--- a/native/src/main/java/bblfsh/CommentVisitor.java
+++ b/native/src/main/java/bblfsh/CommentVisitor.java
@@ -1,0 +1,72 @@
+package bblfsh;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.BlockComment;
+import org.eclipse.jdt.core.dom.Comment;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.LineComment;
+
+public class CommentVisitor extends ASTVisitor {
+
+    CompilationUnit compilationUnit;
+
+    private String[] source;
+    private String commentText;
+
+    public CommentVisitor(CompilationUnit compilationUnit, String[] source) {
+
+        super();
+        this.compilationUnit = compilationUnit;
+        this.source = source;
+    }
+
+    public String getCommentText() {
+        return commentText;
+    }
+
+    public boolean visit(LineComment node) {
+
+        int startLineNumber = compilationUnit.getLineNumber(node.getStartPosition()) - 1;
+        int startLineColumn = compilationUnit.getColumnNumber(node.getStartPosition());
+        commentText = source[startLineNumber].substring(startLineColumn).trim();
+
+        return true;
+    }
+
+    public boolean visit(Javadoc node) {
+        return visitBlock(node);
+    }
+
+    public boolean visit(BlockComment node) {
+        return visitBlock(node);
+    }
+
+    private boolean visitBlock(Comment node) {
+
+        int startLineNumber = compilationUnit.getLineNumber(node.getStartPosition()) - 1;
+        int startLineColumn = compilationUnit.getColumnNumber(node.getStartPosition());
+
+        int endLineNumber = compilationUnit.getLineNumber(node.getStartPosition() + node.getLength()) - 1;
+        int endLineColumn = compilationUnit.getColumnNumber(node.getStartPosition() + node.getLength());
+
+        StringBuffer blockComment = new StringBuffer();
+
+        for (int lineCount = startLineNumber ; lineCount <= endLineNumber; lineCount++) {
+
+            int startCol = lineCount == startLineNumber ? startLineColumn : 0;
+            int endCol = lineCount == endLineNumber ? endLineColumn : source[lineCount].length();
+            String blockCommentLine = source[lineCount].substring(startLineColumn, endCol).trim();
+
+            blockComment.append(blockCommentLine);
+            if (lineCount != endLineNumber) {
+                blockComment.append("\n");
+            }
+        }
+
+        commentText = blockComment.toString();
+
+        return true;
+    }
+}

--- a/native/src/main/java/bblfsh/Driver.java
+++ b/native/src/main/java/bblfsh/Driver.java
@@ -47,6 +47,7 @@ public class Driver {
         }
 
         final Response response = this.processRequest(request);
+        this.writer.setContent(request.content);
         try {
             this.writer.write(response);
         } catch (IOException ex) {

--- a/native/src/main/java/bblfsh/ResponseWriter.java
+++ b/native/src/main/java/bblfsh/ResponseWriter.java
@@ -15,6 +15,8 @@ public class ResponseWriter {
 
     private final OutputStream out;
     private final ObjectMapper mapper;
+    private String content;
+    private CompilationUnitSerializer cu;
 
     public ResponseWriter(final OutputStream out) {
         this.out = out;
@@ -24,8 +26,14 @@ public class ResponseWriter {
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         mapper.enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
         SimpleModule module = new SimpleModule();
-        module.addSerializer(CompilationUnit.class, new CompilationUnitSerializer());
+        cu = new CompilationUnitSerializer();
+        module.addSerializer(CompilationUnit.class, cu);
         mapper.registerModule(module);
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+        cu.setContent(content);
     }
 
     public void write(final Response response) throws IOException {


### PR DESCRIPTION
- The comment/javadoc text wasn't being included in the AST/UAST. Fixes #67.
- Remove the comment marks in line with the other drivers.

Note for reviewers: there are changes in the native driver but can easily be lost among the integration tests' changes. Just search for "bblfsh/".