### PR TITLE
Fix typo in comments processor

### DIFF
--- a/native/src/main/java/bblfsh/CommentVisitor.java
+++ b/native/src/main/java/bblfsh/CommentVisitor.java
@@ -57,7 +57,8 @@ public class CommentVisitor extends ASTVisitor {
 
             int startCol = lineCount == startLineNumber ? startLineColumn : 0;
             int endCol = lineCount == endLineNumber ? endLineColumn : source[lineCount].length();
-            String blockCommentLine = source[lineCount].substring(startLineColumn, endCol).trim();
+
+            String blockCommentLine = source[lineCount].substring(startCol, endCol).trim();
 
             blockComment.append(blockCommentLine);
             if (lineCount != endLineNumber) {

--- a/native/src/main/java/bblfsh/Main.java
+++ b/native/src/main/java/bblfsh/Main.java
@@ -12,6 +12,7 @@ public class Main {
         } catch (CloseException e) {
             System.exit(0);
         } catch (DriverException e) {
+            e.printStackTrace(System.err);
             System.exit(1);
         }
     }

--- a/native/src/test/java/bblfsh/DriverTest.java
+++ b/native/src/test/java/bblfsh/DriverTest.java
@@ -69,4 +69,18 @@ public class DriverTest {
         final String result = new String(out.toByteArray());
         assertThat(result).isEqualTo("{\"status\":\"fatal\",\"errors\":[\"Unrecognized token 'garbage': was expecting ('true', 'false' or 'null')\\n at [Source: garbage; line: 1, column: 15]\"]}\n");
     }
+
+    @Test
+    public void processComment() throws DriverException, CloseException {
+        final String input = "{\"content\":\"class EOF_Test { public void method() {\\r\\n   /*\\r\\n*/ } }\"}";
+        final InputStream in = new ByteArrayInputStream(input.getBytes());
+        final RequestReader reader = new RequestReader(in);
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final ResponseWriter writer = new ResponseWriter(out);
+
+        final Driver driver = new Driver(reader, writer);
+        driver.processOne();
+        //TODO: check output
+    }
 }


### PR DESCRIPTION
* print exceptions to stderr instead of silently dropping them

* fix index out of range exception caused by a typo