### PR TITLE
A more OS-agnostic version of readlink

### DIFF
--- a/native/src/main/sh/native.sh
+++ b/native/src/main/sh/native.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 JAR=native-jar-with-dependencies.jar
-BIN="`readlink -f $0`"
+BIN="`realpath $0`"
 DIR="`dirname "$BIN"`"
 exec java -jar "$DIR/$JAR"


### PR DESCRIPTION
The options of readlink seem to be sensible to the type of OS that is used (linux, alpine, osx, etc.). I feel like using the GNU version would be a less brittle approach.