### PR TITLE
Refurbish native part before SDK update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ build
 
 target
 .m2
+
+.classpath
+.factorypath
+.idea/
+.project
+.settings/
+.vscode/
+*.iml

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -75,6 +75,7 @@
             <version>[2.8.11.3,)</version>
         </dependency>
     </dependencies>
+
     <build>
         <finalName>native</finalName>
         <plugins>
@@ -116,5 +117,18 @@
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <!-- Pin version to workaround
+                    "Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter"
+                    See http://archive.is/uKy4m for details.
+                    TODO(bzz) removed after java is update to >8u191-b12 (does not exist for openjdk:8-slim) -->
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -38,6 +38,7 @@
             <version>3.4</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>org.eclipse.jdt.core</artifactId>
@@ -61,17 +62,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.6</version>
+            <version>[2.8.11.3,)</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.8.6</version>
+            <version>[2.8.11.3,)</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.6</version>
+            <version>[2.8.11.3,)</version>
         </dependency>
     </dependencies>
     <build>
@@ -112,13 +113,6 @@
                             <mainClass>bblfsh/Main</mainClass>
                         </manifest>
                     </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
         </plugins>

--- a/native/src/test/java/bblfsh/DriverTest.java
+++ b/native/src/test/java/bblfsh/DriverTest.java
@@ -67,7 +67,7 @@ public class DriverTest {
         driver.processOne();
 
         final String result = new String(out.toByteArray());
-        assertThat(result).isEqualTo("{\"status\":\"fatal\",\"errors\":[\"Unrecognized token 'garbage': was expecting ('true', 'false' or 'null')\\n at [Source: garbage; line: 1, column: 15]\"]}\n");
+        assertThat(result).isEqualTo("{\"status\":\"fatal\",\"errors\":[\"Unrecognized token 'garbage': was expecting ('true', 'false' or 'null')\\n at [Source: (String)\\\"garbage\\\"; line: 1, column: 15]\"]}\n");
     }
 
     @Test


### PR DESCRIPTION
This is a face-lift kicking some bit-rot in the native driver before bumping SDK version + mapping update.

Includes
 - bump version of JSON parser to mitigate _11 new CVEs_ 😆 
 - fix test fixtures
 - tiny `pom.xml` cleanup
 - ~`bblfsh-sdk update` changes~ needs to be done in sync with actual SDK version update https://github.com/bblfsh/java-driver/pull/107#discussion_r260864680 / bblfsh/sdk#325