### PR TITLE
Fix native tests

### DIFF
--- a/native/src/test/java/bblfsh/DriverTest.java
+++ b/native/src/test/java/bblfsh/DriverTest.java
@@ -74,8 +74,8 @@ public class DriverTest {
         driver.processOne();
 
         final String result = new String(out.toByteArray());
-        assertThat(result).isEqualTo(
-                "{\"status\":\"fatal\",\"errors\":[\"Unrecognized token 'garbage': was expecting ('true', 'false' or 'null')\\n at [Source: (String)\\\"garbage\\\"; line: 1, column: 15]\"]}\n");
+        assertThat(result).contains("{\"status\":\"fatal\",\"errors\":[\"");
+        assertThat(result).contains("Unrecognized token 'garbage'");
     }
 
     @Test


### PR DESCRIPTION
Recently native tests started to fail. I think this is due to the way we check error text in the native test:
```
"{\"status\":\"fatal\",\"errors\":[\"Unrecognized token 'garbage': was expecting ('true', 'false' or 'null')\\n at [Source: (String)\\\"garbage\\\"; line: 1, column: 15]\"]}\n");
```
Adding/changing error formatting will easily break it.

This PR changes the assertion to look for a specific messages in the output instead of comparing the whole text.

Signed-off-by: Denys Smirnov <denis.smirnov.91@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/java-driver/134)
<!-- Reviewable:end -->
